### PR TITLE
fire routingerror event correctly if Mapbox API returns an error key

### DIFF
--- a/src/L.Routing.Mapbox.js
+++ b/src/L.Routing.Mapbox.js
@@ -55,13 +55,13 @@
 
 				clearTimeout(timer);
 				if (!timedOut) {
-					if (!err) {
-						data = JSON.parse(resp.responseText);
+					data = JSON.parse(resp.responseText);
+					if (!err && !data.hasOwnProperty('error')) {
 						this._routeDone(data, wps, callback, context);
 					} else {
 						callback.call(context || callback, {
 							status: -1,
-							message: 'HTTP request failed: ' + err
+							message: 'HTTP request failed: ' + (err || data.error)
 						});
 					}
 				}

--- a/src/L.Routing.Mapbox.js
+++ b/src/L.Routing.Mapbox.js
@@ -55,7 +55,7 @@
 
 				clearTimeout(timer);
 				if (!timedOut) {
-					data = JSON.parse(resp.responseText);
+					data = resp && resp.responseText ? JSON.parse(resp.responseText) : {};
 					if (!err && !data.hasOwnProperty('error')) {
 						this._routeDone(data, wps, callback, context);
 					} else {


### PR DESCRIPTION
The Mapbox Directions API seems to return a 200 response with an 'error' key in the JSON if a routing request fails. Lrm-mapbox does not fire the routingerror event correctly in this case.

This PR should fix that.

Example request that fails: https://api.tiles.mapbox.com/v4/directions/mapbox.driving/4.9276667,52.3845195,;5,1.json?instructions=true&alternatives=true&geometry=polyline&access_token=pk.eyJ1Ijoic2FuamF5YiIsImEiOiJjaWZzMjMyMGgxNnJrc3BrcjZhM2ZiZHR4In0.0pFYU5tHm1tuFYhTAva1SA
